### PR TITLE
Update camera_host.py

### DIFF
--- a/scripts/camera_host.py
+++ b/scripts/camera_host.py
@@ -81,7 +81,7 @@ class BaxterCamera_impl(object):
         self._camera_name = camera_name;
         
         # automatically close camera at start
-        self._camera.close()
+        # self._camera.close()
         self._camera_open = False
         
         # set constant ImageHeader structure


### PR DESCRIPTION
**Bug Fix** - the line of code will create a proxy when constructing the object, which will throw an error. Deleting it makes it work. *The camera needs to be powered on but closed in ROS first.*